### PR TITLE
Fix 502 errors from AirNow fallback loop

### DIFF
--- a/app/api/conditions/route.js
+++ b/app/api/conditions/route.js
@@ -27,27 +27,41 @@ const postHandler = async (req) => {
         const todayDate = `${year}-${month}-${date}`;
         const openWeatherUrl = `https://api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&units=imperial&appid=${process.env.OW_API_KEY}`;
 
-        const weatherResp = await fetch(openWeatherUrl);
+        // Fetch weather and first AirNow call in parallel
+        const firstAirNowUrl = `https://www.airnowapi.org/aq/observation/latLong/current/?format=application/json&latitude=${latitude}&longitude=${longitude}&date=${todayDate}&distance=50&API_KEY=${process.env.AN_API_KEY}`;
+        const [weatherResp, firstAirResp] = await Promise.all([
+            fetch(openWeatherUrl),
+            fetch(firstAirNowUrl),
+        ]);
+
         if (!weatherResp.ok) {
             return new Response(JSON.stringify({ error: 'Upstream service error' }), { status: 502 });
         }
         const weatherData = await weatherResp.json();
 
-        // Try AirNow with increasing search radii until data is found
-        const searchDistances = [50, 100, 150, 200];
         let airData = [];
         let usedDistance = null;
 
-        for (const distance of searchDistances) {
-            const airNowUrl = `https://www.airnowapi.org/aq/observation/latLong/current/?format=application/json&latitude=${latitude}&longitude=${longitude}&date=${todayDate}&distance=${distance}&API_KEY=${process.env.AN_API_KEY}`;
-            const airResp = await fetch(airNowUrl);
-            if (!airResp.ok) {
-                return new Response(JSON.stringify({ error: 'Upstream service error' }), { status: 502 });
-            }
-            airData = await airResp.json();
-            if (airData.length > 0) {
-                usedDistance = distance;
-                break;
+        if (firstAirResp.ok) {
+            airData = await firstAirResp.json();
+            if (airData.length > 0) usedDistance = 50;
+        }
+
+        // If no data within 50 miles, try increasing radii
+        if (airData.length === 0) {
+            for (const distance of [100, 150, 200]) {
+                const airNowUrl = `https://www.airnowapi.org/aq/observation/latLong/current/?format=application/json&latitude=${latitude}&longitude=${longitude}&date=${todayDate}&distance=${distance}&API_KEY=${process.env.AN_API_KEY}`;
+                try {
+                    const airResp = await fetch(airNowUrl);
+                    if (!airResp.ok) continue;
+                    airData = await airResp.json();
+                    if (airData.length > 0) {
+                        usedDistance = distance;
+                        break;
+                    }
+                } catch {
+                    continue;
+                }
             }
         }
 


### PR DESCRIPTION
- Fetch weather and first AirNow call in parallel (restoring original behavior for the common case and saving time)
- Wrap fallback distance attempts in try/catch and skip on non-OK responses instead of propagating AirNow errors as 502s (prevents rate-limit responses from aborting the request)

https://claude.ai/code/session_01PR5g27r9SfEjotyRiDNYX7