### PR TITLE
Fix error banner invisible due to missing red color in Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,7 @@ module.exports = {
             gray: colors.gray,
             amber: colors.amber,
             indigo: colors.indigo,
+            red: colors.red,
             yellow: colors.yellow,
             fire: {
                 '50': '#fcf6ee',


### PR DESCRIPTION
The theme.colors object in tailwind.config.js completely replaces the
default palette. Since red was not included, bg-red-600 and text-white
on the ErrorBanner produced no visible styling (white on white).

https://claude.ai/code/session_01WmmwM195fJZWkGV1Pa37Du