### PR TITLE
Clear error banner when user retries an action

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -34,6 +34,12 @@ export default function HomePage() {
         }
     }, []);
 
+    useEffect(() => {
+        if (haveUserCityZip || permissionGranted) {
+            setError(null);
+        }
+    }, [haveUserCityZip, permissionGranted]);
+
     useInterval(() => {
         if (coordinates) {
             fetchConditions();


### PR DESCRIPTION
Add a useEffect that clears the error state when haveUserCityZip or
permissionGranted becomes true, so the banner disappears as soon as
the user submits a new location or triggers geolocation.

https://claude.ai/code/session_01DWTEwk13M86PwfN2iwV4Uk